### PR TITLE
Display multiple markers on one map

### DIFF
--- a/Classes/Hooks/PageLayoutViewDrawItemHook.php
+++ b/Classes/Hooks/PageLayoutViewDrawItemHook.php
@@ -94,14 +94,14 @@ class PageLayoutViewDrawItemHook implements PageLayoutViewDrawItemHookInterface 
 			//Get Map records
 			preg_match_all( '/tx_rtsimpleosm_domain_model_osm_(\d+),?/', $flexform['mapselection']['settings.MapRecord'], $mapRecords );
 			$mapRecordIds = array_map( 'intval', $mapRecords[1] );
-			$selectedOsms = [];
+			$selectedMarkers = [];
 
 			if ( version_compare( TYPO3_version, '8.0', '<' ) ) {
 				// Database connection
 				global $TYPO3_DB;
 				$fields       = "`uid`,`title`,`latitude`,`longitude`,`address`";
 				$where_clause = "`uid` IN (" . join( ', ', $mapRecordIds ) . ")";
-				$selectedOsms  = $TYPO3_DB->exec_SELECTgetRows( $fields, $this->osm_table, $where_clause );
+				$selectedMarkers  = $TYPO3_DB->exec_SELECTgetRows( $fields, $this->osm_table, $where_clause );
 
 			} elseif ( version_compare( TYPO3_version, '8.0', '>=' ) ) {
 				// Database connection
@@ -109,7 +109,7 @@ class PageLayoutViewDrawItemHook implements PageLayoutViewDrawItemHookInterface 
 				$pageQueryBuilder = $connectionPool->getQueryBuilderForTable( $this->osm_table );
 
 				// Get OSM infos
-				$selectedOsms = $pageQueryBuilder
+				$selectedMarkers = $pageQueryBuilder
 					->select( 'uid', 'title', 'latitude', 'longitude', 'address' )
 					->from( $this->osm_table )
 					->where(
@@ -119,18 +119,18 @@ class PageLayoutViewDrawItemHook implements PageLayoutViewDrawItemHookInterface 
 					->fetchAll();
 			}
 
-			$osms = [];
-			foreach ( $selectedOsms as $selectedOsm ) {
-				$osms[] = [
+			$markers = [];
+			foreach ( $selectedMarkers as $selectedMarker ) {
+				$markers[] = [
 					'icon' => '../typo3conf/ext/rt_simpleosm/Resources/Public/Icons/user_plugin_sosm.svg',
-					'uid' => $selectedOsm['uid'],
-					'title' => $selectedOsm['title'],
-					'latitude' => '<strong><em>' . LocalizationUtility::translate('LLL:EXT:rt_simpleosm/Resources/Private/Language/locallang_db.xlf:tx_rtsimpleosm_domain_model_osm.latitude', 'rt_simpleosm') . '</em></strong>: ' . $selectedOsm['latitude'] . '.<br />',
-					'longitude' => '<strong><em>' . LocalizationUtility::translate('LLL:EXT:rt_simpleosm/Resources/Private/Language/locallang_db.xlf:tx_rtsimpleosm_domain_model_osm.longitude', 'rt_simpleosm') . '</em></strong>: ' . $selectedOsm['longitude'] . '.<br />',
-					'address' => '<strong><em>' . LocalizationUtility::translate('LLL:EXT:rt_simpleosm/Resources/Private/Language/locallang_db.xlf:tx_rtsimpleosm_domain_model_osm.address', 'rt_simpleosm') . '</em></strong>: ' . $selectedOsm['address'] . '.<br />',
+					'uid' => $selectedMarker['uid'],
+					'title' => $selectedMarker['title'],
+					'latitude' => '<strong><em>' . LocalizationUtility::translate('LLL:EXT:rt_simpleosm/Resources/Private/Language/locallang_db.xlf:tx_rtsimpleosm_domain_model_osm.latitude', 'rt_simpleosm') . '</em></strong>: ' . $selectedMarker['latitude'] . '.<br />',
+					'longitude' => '<strong><em>' . LocalizationUtility::translate('LLL:EXT:rt_simpleosm/Resources/Private/Language/locallang_db.xlf:tx_rtsimpleosm_domain_model_osm.longitude', 'rt_simpleosm') . '</em></strong>: ' . $selectedMarker['longitude'] . '.<br />',
+					'address' => '<strong><em>' . LocalizationUtility::translate('LLL:EXT:rt_simpleosm/Resources/Private/Language/locallang_db.xlf:tx_rtsimpleosm_domain_model_osm.address', 'rt_simpleosm') . '</em></strong>: ' . $selectedMarker['address'] . '.<br />',
 				];
 			}
-			$flex['contents']['markers'] = $osms;
+			$flex['contents']['markers'] = $markers;
 		}
 
 		if ( !empty( $flexform['styling']['settings.MapStyle'] || $flexform['styling']['settings.MapStyle'] === '0') ) {

--- a/Configuration/FlexForms/flexform_simpleosm.xml
+++ b/Configuration/FlexForms/flexform_simpleosm.xml
@@ -15,13 +15,11 @@
                             <type>group</type>
                             <internal_type>db</internal_type>
                             <allowed>tx_rtsimpleosm_domain_model_osm</allowed>
-                            <size>1</size>
+                            <size>3</size>
 							<minitems>1</minitems>
-							<maxitems>1</maxitems>
 							<eval>required</eval>
                         </config>
 					</settings.MapRecord>
-
 				</el>
 			</ROOT>
 		</mapselection>

--- a/Resources/Private/Templates/Backend/Rtsimpleosm-Plugin-BackendTemplate.html
+++ b/Resources/Private/Templates/Backend/Rtsimpleosm-Plugin-BackendTemplate.html
@@ -7,12 +7,17 @@
             <f:if condition="{flex.contents}">
                 <f:then>
                     <li class="list-group-item">
-                        <img src="{flex.contents.osm.icon}" alt="osm">&nbsp;
-                        <strong>{flex.contents.osm.title}</strong>&nbsp;
-                        [{flex.contents.osm.uid}]<br />
-                        <f:format.raw>{flex.contents.osm.address}</f:format.raw>
-                        <f:format.raw>{flex.contents.osm.latitude}</f:format.raw>
-                        <f:format.raw>{flex.contents.osm.longitude}</f:format.raw>
+                      <ul class="list-group">
+                        <f:for each="{flex.contents.markers}" as="osm">
+                          <li class="list-group-item">
+                            <img src="{osm.icon}" alt="osm">&nbsp;
+                            <strong>{osm.title}</strong>&nbsp;[{osm.uid}]<br />
+                            <f:format.raw>{osm.address}</f:format.raw>
+                            <f:format.raw>{osm.latitude}</f:format.raw>
+                            <f:format.raw>{osm.longitude}</f:format.raw>
+                          </li>
+                        </f:for>
+                      </ul>
                     </li>
                     <li class="list-group-item">
                         <f:image width="75" height="75" src="{flex.contents.mapStyleImg}" alt="map_style" /><br />


### PR DESCRIPTION
# Abstract

Extends the plugin to display multiple markers on one map

## Changes

* Map is now dynamically centred to display all the selected markers (using [`fitBounds`](https://leafletjs.com/reference-1.4.0.html#map-fitbounds)). Zoom level is respected, unless too high to display all markers.
  * If there is only one marker, the exact same logic is used. Map will be centred around the marker, just as it used to be.
* Since the pop-up content had to be calculated for several markers, I made a function out of it. 

## Screenshots
| Backend   |      Frontend      |
|--------------|---------------------|
| ![image](https://user-images.githubusercontent.com/1093360/55415898-2c545a80-556e-11e9-925e-7a5c0c97bbb3.png) |  ![image](https://user-images.githubusercontent.com/1093360/55415959-45f5a200-556e-11e9-84d8-b948679eb2b7.png) |

# Notes

* I chose to use the word "markers" instead of "osms", because pluralizing OSM didn't feel right and was quite cryptical. This is something I can change back if needed :wink: 
* While working on the plugin, I noticed the DragIn Wizard wasn't working for the plug-in (Typo3 8.7) because `$row['pi_flexform']` was empty. I implemented [a temporary workaround](https://github.com/Treedent/rt_simpleosm/pull/2/files#diff-3ccbae599bf172bc77c28e4cbe4a6f35R50)
* It might make sense to output translations in the Fluid template instead of the Hook (see [POC](https://github.com/YKWeyer/rt_simpleosm/compare/feature/multimarkers...YKWeyer:feature/multimarkers-translation))